### PR TITLE
release: `0.1.6`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ keywords = ["serialization", "deserialization", "serde", "serialize", "deseriali
 license = "MIT"
 name = "serde_gura"
 repository = "https://github.com/gura-conf/serde-gura"
-version = "0.1.5"
+version = "0.1.6"
 
 [dependencies]
-gura = "0.5.0"
-indexmap = "1.7.0"
+gura = "0.5"
+indexmap = "1.9"
 serde = "1.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following dependencies to your `Cargo.toml`:
 ```toml
 [dependencies]
 serde = "1.0"
-serde_gura = "0.1.4"
+serde_gura = "0.1"
 ```
 
 If you want to use `Serialize`/`Deserialize` traits you must specify the *derive* feature in your `Cargo.toml`:
@@ -28,7 +28,7 @@ If you want to use `Serialize`/`Deserialize` traits you must specify the *derive
 ```toml
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_gura = "0.1.4"
+serde_gura = "0.1"
 ```
 
 


### PR DESCRIPTION
- Adjusts `gura` dependency to use any patch. Needed for [the `0.5.2` bugfix](https://github.com/gura-conf/gura-rs-parser/issues/12#issuecomment-1751742271).
- `indexmap` bumped to `1.9`, which raises the MSRV from [1.49](https://github.com/rust-lang/rust/releases/tag/1.49.0) (Jan 2021) to [1.56](https://github.com/rust-lang/rust/releases/tag/1.56.0) (Oct 2021).

---

The `indexmap` version bump is not necessary, beyond the implicit MSRV bump it seems fine? (_[Release Notes](https://github.com/bluss/indexmap/blob/master/RELEASES.md)_)

`indexmap` has a `2.x` release now as well, but I've not looked into if breaking changes affect `serde-gura` usage. That would also raise the MSRV to [`1.63`](https://github.com/rust-lang/rust/releases/tag/1.63.0) (Aug 2022).